### PR TITLE
Use the mermaid render API to get useful error messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const puppeteer = require("puppeteer");
 const SCRIPT_ERROR =
   "Invalid script identifier. Please see: https://github.com/muhammadmuzzammil1998/headless-mermaid#calling-the-api";
 
-async function execute(code, config = {}, script = "mermaid.min@8.5.2") {
+async function execute(code, config = {}, script = "mermaid.min@8.5.2", diagramId = "id1") {
   let browser = await puppeteer.launch({ args: ["--no-sandbox"] }),
     scriptData = script.split("@").map((x) => x.trim());
   if (scriptData.filter((x) => x != "").length < 2) {
@@ -18,22 +18,27 @@ async function execute(code, config = {}, script = "mermaid.min@8.5.2") {
   try {
     let page = await browser.newPage();
     await page.goto(
-      `data:text/html,<script src="https://cdnjs.cloudflare.com/ajax/libs/mermaid/${version}/${filename}"></script><div id="mermaid">${code}</div>`
+      `data:text/html,<script src="https://cdnjs.cloudflare.com/ajax/libs/mermaid/${version}/${filename}"></script>`
     );
-    await page.$eval(
-      "#mermaid",
-      (container, config) => {
+    const result = await page.evaluate(
+      (config, code, diagramId) => {
         window.mermaid.initialize(config);
-        window.mermaid.init(config, container);
+        try {
+          const svgCode = window.mermaid.mermaidAPI.render(diagramId, code);
+          return { status: "success", svgCode };
+        } catch (error) {
+          return { status: "error", error, message: error.message };
+        }
       },
-      config
+      config, code, diagramId
     );
+    if (result.status === "error") {
+      throw `Mermaid error:\n${result.message}`;
+    }
 
-    return await page.$eval("#mermaid", (container) =>
-      container.innerHTML.replace(
-        "</svg>",
-        "<!-- Rendered using headless-mermaid - npmjs.com/headless-mermaid --> </svg>"
-      )
+    return result.svgCode.replace(
+      "</svg>",
+      "<!-- Rendered using headless-mermaid - npmjs.com/headless-mermaid --> </svg>"
     );
   } finally {
     await browser.close();


### PR DESCRIPTION
Thank you for this very nice library! It's doing exactly what I needed. However, one problem I had was that I cannot see the error messages from mermaid when I run this code, because the error happens in puppeteer and stays in there.

I solved this problem by using `mermaidAPI.render()` which is described [here in the documentation](https://mermaid-js.github.io/mermaid/#/usage?id=api-usage).

So, with the following input:
```
graph LR
  A[foo)
```
the code now throws this error:
```
Mermaid error:
Parse error on line 2:
graph LR  A[A)
-------------^
Expecting 'SPACE', 'GRAPH', 'DIR', 'subgraph', 'SQE', 'end', 'AMP', 'ALPHA', 'COLON', 'TAGEND', 'START_LINK', 'STYLE', 'LINKSTYLE', 'CLASSDEF', 'CLASS', 'CLICK', 'DOWN', 'UP', 'DEFAULT', 'NUM', 'COMMA', 'MINUS', 'BRKT', 'DOT', 'PCT', 'TAGSTART', 'PUNCTUATION', 'UNICODE_TEXT', 'PLUS', 'EQUALS', 'MULT', 'UNDERSCORE', got 'PE'
```
But otherwise, everything should work exactly as before.